### PR TITLE
Import pyclamd after cn_log

### DIFF
--- a/pyew_batch.py
+++ b/pyew_batch.py
@@ -10,15 +10,15 @@ from hashlib import sha1
 sys.path.append("pyew")
 from pyew_core import CPyew
 
+from cn_log import log
+from cn_db import init_web_db
+from cosa_nostra import open_db
+
 try:
   import pyclamd
 except ImportError:
   log("No pyclamd support, files will not have a description.")
   pyclamd = None
-
-from cn_log import log
-from cn_db import init_web_db
-from cosa_nostra import open_db
 
 #-----------------------------------------------------------------------
 ANALYSIS_FAILED = 0
@@ -52,7 +52,7 @@ class CPyewAnalyser:
     self.primes_table = primes(16384*4)
     self.db = open_db()
     self.db.printing = False
-    
+
     self.clamd = None
     if pyclamd is not None:
       self.clamd = pyclamd.ClamdAgnostic()
@@ -127,7 +127,7 @@ class CPyewAnalyser:
         edges.append(pyew.function_stats[x][1])
         cc = pyew.function_stats[x][2]
         ccs.append(cc)
-        
+
         prime = self.primes_table[cc]
         callgraph *= prime
         primes.append(prime)

--- a/r2_batch.py
+++ b/r2_batch.py
@@ -16,15 +16,15 @@ try:
 except ImportError:
   from StringIO import StringIO
 
+from cn_log import log
+from cn_db import init_web_db
+from cosa_nostra import open_db
+
 try:
   import pyclamd
 except ImportError:
   log("No pyclamd support, files will not have a description.")
   pyclamd = None
-
-from cn_log import log
-from cn_db import init_web_db
-from cosa_nostra import open_db
 
 #-----------------------------------------------------------------------
 ANALYSIS_FAILED = 0
@@ -63,7 +63,7 @@ class CR2Analyser:
     self.primes_table = primes(16384*4)
     self.db = open_db()
     self.db.printing = False
-    
+
     self.r2 = None
     self.clamd = None
     if pyclamd is not None:
@@ -101,7 +101,7 @@ class CR2Analyser:
       if len(fields) > 1:
         f1, f2 = fields[0], fields[1]
         l.add((f1, f2))
-        
+
         if len(fields) > 4:
           print "fields", fields
           is_jump = False
@@ -111,7 +111,7 @@ class CR2Analyser:
             elif is_jump:
               l.add((f1, field))
               is_jump = False
-    
+
     print l
     print len(l)
     raw_input("?")
@@ -188,7 +188,7 @@ class CR2Analyser:
         nodes.append(f_nodes)
         edges.append(f_edges)
         ccs.append(f_cc)
-        
+
         prime = self.primes_table[f_cc]
         callgraph *= prime
         primes.append(prime)


### PR DESCRIPTION
Fixes "NameError: name 'log' is not defined" if pyclamd is not installed. Interestingly, the ida_batch script already had the right order, it's just the pyew and r2 batch scripts who had this issue.